### PR TITLE
General guidelines section update

### DIFF
--- a/howtoreview.Rmd
+++ b/howtoreview.Rmd
@@ -1,4 +1,4 @@
-# Cómo traducir y revisar
+# Translation and Review Guidelines 
 
 ::: callout-note
 

--- a/howtoreview.es.Rmd
+++ b/howtoreview.es.Rmd
@@ -4,21 +4,7 @@ editor:
     wrap: sentence
 ---
 
-# Cómo traducir y revisar
-
-## Aspectos generales
-
-El proceso de traducción comienza con una primera traducción automática usando el paquete [babeldown](https://docs.ropensci.org/babeldown/).
-Esto brinda un primer borrador que luego es revisado por ojos humanos, quienes corrigen errores e incorporan los acuerdos de localización y traducción del lenguaje (ver [Guía específica para español](specific_guidelines.html)).
-
-Para minimizar errores y mantener una mirada amplia sobre la traducción, desde rOpenSci pedimos que cada capítulo o sección conste con al menos 2 revisiones realizadas en serie (la primera revisa el borrador automático y la segunda revisa la primera revisión) seguida de una revisión general de todo el libro o documentos en su conjunto.
-
-Estas revisiones se hacen en GitHub usando *pull requests* (ver [esta sección](#0) para más detalles).
-Elegimos este flujo de trabajo ya que esta es la infraestructura que usamos en nuestra comunidad.
-Todos nuestros paquetes y libros se alojan en GitHub y usan *issues* y *pull requests* en su desarrollo.
-Además, esto permite que el proceso sea abierto para que otras personas puedan contribuir y opinar.
-
-Por supuesto, como en todos los ámbitos de rOpenSci, seguimos nuestro [código de conducta](https://ropensci.org/es/codigo-de-conducta/) para generar un ambiente amigable y seguro.
+# Guía para traducir y revisar
 
 ## Cómo colaborar
 
@@ -172,7 +158,7 @@ Para esto hay que tener en cuenta:
 Es posible que en el proceso de la revisión 2 necesites consultar con R1 sobre las decisiones que tomó o con el resto de la comunidad si hay alguna frase o término que te genera dudas.
 Es posible que luego de esto sugieras incorporar nuevos términos al glosario o actualizar esta guía de traducción.
 
-### Pull Request y edición de un capítulo
+### Pull Request y edición de un capítulo {#pr-edition}
 
 Una vez que el proceso de revión de un capítulo está completo, es hora de transferir esa nueva versión del repositorio de trabajo al repositorio principal de rOpenSci.
 Para esto **R2** tendrá que abrir un *pull request* que comparé la versión revisada con la versión que solo tiene traducción automática.

--- a/index.Rmd
+++ b/index.Rmd
@@ -63,3 +63,7 @@ If you want to contribute to this book, corrections, additions, and suggestions 
 Thanks!
 
 You can also read the [PDF version](/ropensci-translation-guide.pdf) of this book.
+
+## Attributions
+
+These translation guidelines are based on the experience and documents generated during the translation of [Teaching Tech Together](https://github.com/gvwilson/teachtogether.tech/blob/main/README.md).

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -26,8 +26,36 @@ There are many solutions for internationalizing and localizing content and softw
 
 Based on our previous experiences and using the characteristics of our community, we develop tools and a technical workflow for performing localizations and achieve stage 1.  
 
-## 
+## General aspects of the translation process
+
+The translation process starts with a first machine translation using the [babeldown](https://docs.ropensci.org/babeldown/) package.
+This provides a first draft that is then reviewed by human eyes, who correct errors and incorporate the localization and language translation agreements (see [Languaje specific guidelines](specific_guidelines.html)).
+
+To minimize errors and maintain a broad look at the translation, we at rOpenSci ask that each chapter or section goes through of at least 2 reviews done in series (the first one reviews the automatic translation and the second reviews the first review) followed by a general review and edition of the book or document as a whole.
+
+In each step of this process we ask you to:
+
+1.  Use a conversational voice rather than a formal or academic voice.
+
+2.  If appropriate, specify what dialect or regional variation of the language is being used. 
+For example, the Spanish translation uses Latin American conventions.
+
+3.  Try to be gender neutral. 
+Unlike English, Spanish has a strongly grammatical gender (masculine and feminine with very few neutrals). 
+That translation adjusts wording to avoid having to assign a gender. 
+Where a gender mark cannot be avoided, it uses feminine-masculine or masculine-feminine splits. 
+For consistency throughout the text and to show that there is no particular hierarchy, it alternates the use of feminine or masculine between chapters, with the use being consistent throughout each chapter.
+
+4.  Try to be idiomatic. 
+For example, since Spanish verbs have the mark of person, gender, and number, the Spanish translation can omit subjects that are present in the English original: because of the context, readers will understand what is being referred to. 
+Similarly, Spanish has more verb tenses than English. 
+When translating, the verbal form that is best to express the meaning of the fragment in Spanish should be prioritized, not the one that seems to be literal from English.
+
+The translation and review process is done on GitHub using *pull requests* (see [this section](#pr-edition) for details).
+We chose this workflow as this is the infrastructure we use in our community.
+All our packages and books are hosted on GitHub and use *issues* and *pull requests* in their development.
+In addition, this allows the process to be open so that others can contribute and provide feedback.
 
 ## References.
 
-[^1] Internationalization and localization. Access November 1, 2022. https://en.wikipedia.org/wiki/Internationalization_and_localization
+[^1]: Internationalization and localization. Access November 1, 2022. https://en.wikipedia.org/wiki/Internationalization_and_localization

--- a/intro.Rmd
+++ b/intro.Rmd
@@ -56,6 +56,20 @@ We chose this workflow as this is the infrastructure we use in our community.
 All our packages and books are hosted on GitHub and use *issues* and *pull requests* in their development.
 In addition, this allows the process to be open so that others can contribute and provide feedback.
 
+## Citing the translation
+
+Citing the translation can change for every language. We base this recommendation on the [APA recomendations article, Section Book, republished in translation](https://apastyle.apa.org/blog/citing-translated-works). We also recommend including the original title in English, [following this APA suggestion](https://writeanswers.royalroads.ca/faq/199295). See example for Piaget (1950).
+
+The general format is:
+
+{list of authors of the English version}.{(year of publication)}. {Translated title}. {[Original Title in English]} (Translation to {language name}: {list of people that translate the material}). {DOI}. (Original work publish at {year of publication})
+
+The text _Translation to_ and _Original work publish at_ should be writing on the language of the translations.
+
+Example using the developer guide:
+
+> rOpenSci, Anderson, Brooke, Chamberlain, Scott, DeCicco, Laura, Gustavsen, Julia, Krystalli, Anna, Lepore, Mauro, Mullen, Lincoln, Ram, Karthik, Ross, Noam, Salmon, Maëlle, Vidoni, Melina, Riederer, Emily, Sparks, Adam, & Hollister, Jeff. (2021). Paquetes rOpenSci: Desarrollo, mantenimiento y revisión por pares [rOpenSci Packages: Development, Maintenance, and Peer Review] (Traducción al español: {name of the translators}) Zenodo. https://doi.org/10.5281/zenodo.6619350 (Trabajo original publicado en 2021)
+
 ## References.
 
 [^1]: Internationalization and localization. Access November 1, 2022. https://en.wikipedia.org/wiki/Internationalization_and_localization

--- a/specific_guidelines.Rmd
+++ b/specific_guidelines.Rmd
@@ -1,35 +1,8 @@
-# Guidelines
+# Specific Guidelines
 
-::: callout-warning
-You are reading the first edition **in progress** of rOpenSci Localization and Translation Guide. 
-This chapter is undergoing major restructuring and may be confusing or incomplete. We do not recommend reading it.
+::: callout-note
+If you want to read the guidelines for a specific language, place change the version of the Translation Guide to that language using the language list on the left.
 :::
-
-This is some guidance to keep in mind when _translating_ rOpenSci materials.
-
-Detailed guidance for Spanish is available in that language in the Spanish translations guidelines.
-
-## Organization of work
-
-This process can be modified for each translation project, but the general steps are as follows:
-
-1. We will have these roles:
-    - Translators
-    - Reviewers
-    - Editors 
-
-2. Each chapter or section of the material to be reviewed will be assigned to a translator and at least one reviewer (it is desirable that it be reviewed by more than one person). It is a good idea to have reviews from differents countries. One person can translate and review more than one chapter.
-
-3. For each chapter/section or material (for example, a blog post or a form):
-
-   - _First step_: the designated translator generates the first version of the translation chapter. Durgin this work the translator should apply the guidelines. If the translator encounter a situation that is not in the guide and they are not sure how to solve it, ask in the Slack in the translations channel.  Update the guide with the agreement reached and apply it to the translation. When the translation is ready, notify the designated reviewer that the review can begin.
-   - _Second step_: The reviewer makes suggestions for changes (based on the guidelines and their understanding of the subject and the language). When finished, let the designated translator knows.
-   - _Third step_: The translator and the reviewer initiate a discussion cycle on the suggestions and comments made in the review. They are accepted, rejected, changed, etc. until all comments and suggestions have been resolved.  
-   - _Four steps_: The translator updates the guide and the list of terms if necessary.
-
-4. When all the chapters/sections are finished, the editor, reads the entire book to check the consistency of the text, and the rules and guidelines. The editor has to read and write in the original language and the language of the translations. If the author of the material is bilingual, then it is a good idea for the author to be the editor. If they can't, we need another person to be the editor.
-
-
 
 ## Technical terms and citations
 
@@ -86,32 +59,5 @@ Translate:
 1. Figure and diagrams are translated.
 2. Screenshots are translated only if the IDE or UI exist in the language of the translation.
 
-# Citing the translation
 
-The cite of the translation change for every language.  We base this recomendations on the [APA recomendations article, Section Book, republished in translation](https://apastyle.apa.org/blog/citing-translated-works). We also recommend including the orginal title in English, [following this APA suggestion](https://writeanswers.royalroads.ca/faq/199295). See example for Piaget (1950).
 
-The general format is:
-
-{list of authors of the English version}.{(year of publication)}. {Translated title}. {[Original Title in English]} (Translation to {language name}: {list of people that translate the material}). {DOI}. (Original work publish at {year of publication})
-
-The text _Translation to_ and _Original work publish at_ should be writing on the language of the translations.
-
-Example using the developer guide:
-
-> rOpenSci, Anderson, Brooke, Chamberlain, Scott, DeCicco, Laura, Gustavsen, Julia, Krystalli, Anna, Lepore, Mauro, Mullen, Lincoln, Ram, Karthik, Ross, Noam, Salmon, Maëlle, Vidoni, Melina, Riederer, Emily, Sparks, Adam, & Hollister, Jeff. (2021). Paquetes rOpenSci: Desarrollo, mantenimiento y revisión por pares [rOpenSci Packages: Development, Maintenance, and Peer Review] (Traducción al español: {name of the translators}) Zenodo. https://doi.org/10.5281/zenodo.6619350 (Trabajo original publicado en 2021)
-  
-  
-## Attributions
-
-These translation guidelines are based on the experience and documents generated during the translation of [Teaching Tech Together](https://github.com/gvwilson/teachtogether.tech/blob/main/README.md).
-
-# Glossary
-
-## Source 
-
-<https://github.com/ropensci-review-tools/glossary>
-
-## Glossary
-
-```{r, file='man/rmd-fragments/query-glossary.R', echo=FALSE, message=FALSE, warning=FALSE}
-```

--- a/specific_guidelines.Rmd
+++ b/specific_guidelines.Rmd
@@ -29,32 +29,7 @@ This process can be modified for each translation project, but the general steps
 
 4. When all the chapters/sections are finished, the editor, reads the entire book to check the consistency of the text, and the rules and guidelines. The editor has to read and write in the original language and the language of the translations. If the author of the material is bilingual, then it is a good idea for the author to be the editor. If they can't, we need another person to be the editor.
 
-## General guidelines
 
-1.  Use a conversational voice rather than a formal or academic voice.
-
-2.  If appropriate, specify what dialect or regional variation of the language is being used.
-    For example, the Spanish translation uses Latin American conventions.
-
-3.  Try to be gender neutral.
-    Unlike English, Spanish has a strongly grammatical gender (masculine and feminine with very few neutrals).
-    That translation adjusts wording to avoid having to assign a gender.
-    Where a gender mark cannot be avoided,
-    it uses feminine-masculine or masculine-feminine splits.
-    For consistency throughout the text and to show that there is no particular hierarchy,
-    it alternates the use of feminine or masculine between chapters,
-    with the use being consistent throughout each chapter.
-
-4.  Try to be idiomatic.
-    For example,
-    since Spanish verbs have the mark of person, gender, and number,
-    the Spanish translation can omit subjects that are present in the English original:
-    because of the context, readers will understand what is being referred to.
-    Similarly,
-    Spanish has more verb tenses than English.
-    When translating,
-    the verbal form that is best to express the meaning of the fragment in Spanish should be prioritized,
-    not the one that seems to be literal from English.
 
 ## Technical terms and citations
 


### PR DESCRIPTION
What does this PR include? A LOT

It focuses on the General Guidelines section (intro.Rmd, only English version). 

**Changes:**

1. Move [general content](https://translationguide.ropensci.org/es/howtoreview.es.html#aspectos-generales) from "Cómo traducir y revisar" to General Guidelines.
2. Move [general guidelines](https://translationguide.ropensci.org/es/howtoreview.es.html#aspectos-generales) to General Guidelines section and merge with 1.

**Pending:**

* ¿Shoud I move [this section](https://translationguide.ropensci.org/specific_guidelines.html#organization-of-work) to General Guidelines also? It's not up to date and the idea is already mentioned in the General Guidelines
* I think the [Specific Guidelines in the English version](https://translationguide.ropensci.org/specific_guidelines.html) should be empty or better mention how to access the specific guidelines for each language. At least until someone starts translating material from other languages to English!

**Technical issues**

howtoreview.Rmd

The same footnote is mentioned 3 times. The rendered version shows 3  footnotes as if they were different